### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/tradingbot-backend/rest/auth.py
+++ b/tradingbot-backend/rest/auth.py
@@ -82,7 +82,7 @@ def redact_headers(headers: dict) -> dict:
     """
     redacted = headers.copy()
     if "bfx-apikey" in redacted and redacted["bfx-apikey"]:
-        redacted["bfx-apikey"] = redacted["bfx-apikey"][:4] + "..." if len(redacted["bfx-apikey"]) > 4 else "***"
+        redacted["bfx-apikey"] = "[REDACTED]"
     if "bfx-signature" in redacted and redacted["bfx-signature"]:
         redacted["bfx-signature"] = "[REDACTED]"
     return redacted
@@ -136,10 +136,10 @@ async def place_order(order: dict) -> dict:
         
         # Logga alla detaljer för debugging
         logger.info(
-            f"🔍 DEBUG: API Key (första 10 chars): {settings.BITFINEX_API_KEY[:10] if settings.BITFINEX_API_KEY else 'None'}..."
+            "🔍 DEBUG: API Key: [REDACTED]"
         )
         logger.info(
-            f"🔍 DEBUG: API Secret (första 10 chars): {settings.BITFINEX_API_SECRET[:10] if settings.BITFINEX_API_SECRET else 'None'}..."
+            "🔍 DEBUG: API Secret: [REDACTED]"
         )
         logger.info(f"🔍 DEBUG: Headers: {redact_headers(headers)}")
         logger.info(f"🔍 DEBUG: Payload: {bitfinex_order}")


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/14](https://github.com/JohnCCarter/Genesis/security/code-scanning/14)

To fix the problem, ensure that no part of the API key or secret is logged, even in debug logs. The `redact_headers` function should fully mask the API key and signature, replacing their values with a placeholder such as "[REDACTED]" or "***". Additionally, the debug log statements on lines 139 and 142, which log the first 10 characters of the API key and secret, should be removed or replaced with a generic message indicating that the credentials are present but not shown. Only non-sensitive information should be logged. The changes should be made in the `place_order` function, specifically on lines 139, 142, and in the `redact_headers` function if necessary.

**Required changes:**
- Update `redact_headers` to fully redact the API key (not just partial).
- Remove or replace log statements on lines 139 and 142 to avoid logging any part of the API key or secret.
- Ensure that line 144 logs only the fully redacted headers.

No new imports or external libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

```markdown
## Sammanfattning av Sourcery

Förhindra loggning i klartext av känsliga API-uppgifter genom att helt maskera nycklar och signaturer och ta bort partiella exponeringar i felsökningsloggar.

Bugfixar:
- Maskera helt API-nyckeln och signaturen i `redact_headers` genom att ersätta deras värden med `"[REDACTED]"`
- Ta bort felsökningsloggmeddelanden som exponerade de första 10 tecknen av API-nyckeln och hemligheten och ersätta dem med ett generiskt `"[REDACTED]"` meddelande
- Säkerställ att felsökningsloggen för rubriker endast visar helt maskerade rubrikvärden
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent clear-text logging of sensitive API credentials by fully redacting keys and signatures and removing partial exposures in debug logs.

Bug Fixes:
- Fully redact the API key and signature in redact_headers by replacing their values with "[REDACTED]"
- Remove debug log statements that exposed the first 10 characters of the API key and secret and replace them with a generic "[REDACTED]" message
- Ensure the debug log for headers only shows fully redacted header values

</details>