### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/tradingbot-backend/rest/auth.py
+++ b/tradingbot-backend/rest/auth.py
@@ -74,7 +74,7 @@ def redact_headers(headers: dict) -> dict:
     """
     redacted = headers.copy()
     if "bfx-apikey" in redacted and redacted["bfx-apikey"]:
-        redacted["bfx-apikey"] = redacted["bfx-apikey"][:4] + "..." if len(redacted["bfx-apikey"]) > 4 else "***"
+        redacted["bfx-apikey"] = "[REDACTED]"
     if "bfx-signature" in redacted and redacted["bfx-signature"]:
         redacted["bfx-signature"] = "[REDACTED]"
     return redacted


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/14](https://github.com/JohnCCarter/Genesis/security/code-scanning/14)

To fix the problem, we should ensure that no part of the API key or secret is ever logged, even in redacted or truncated form. The `redact_headers` function should be updated to fully redact the API key (e.g., replace with "[REDACTED]" or "***"), and the log message on line 136 should use this fully redacted version. This change should be made in `tradingbot-backend/rest/auth.py`, specifically in the `redact_headers` function and the log statement on line 136. No new imports are needed, and the rest of the code can remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
