### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/tradingbot-backend/rest/auth.py
+++ b/tradingbot-backend/rest/auth.py
@@ -131,7 +131,7 @@ async def place_order(order: dict) -> dict:
             f"🔍 DEBUG: API Key (första 10 chars): {settings.BITFINEX_API_KEY[:10] if settings.BITFINEX_API_KEY else 'None'}..."
         )
         logger.info(
-            f"🔍 DEBUG: API Secret (första 10 chars): {settings.BITFINEX_API_SECRET[:10] if settings.BITFINEX_API_SECRET else 'None'}..."
+            f"🔍 DEBUG: API Secret: {'set' if settings.BITFINEX_API_SECRET else 'not set'}"
         )
         logger.info(f"🔍 DEBUG: Headers: {redact_headers(headers)}")
         logger.info(f"🔍 DEBUG: Payload: {bitfinex_order}")

--- a/tradingbot-backend/rest/auth.py
+++ b/tradingbot-backend/rest/auth.py
@@ -131,11 +131,11 @@ async def place_order(order: dict) -> dict:
             f"🔍 DEBUG: API Key is {'set' if settings.BITFINEX_API_KEY else 'not set'}"
         )
         logger.info(
-        alert-autofix-3
+        
             f"🔍 DEBUG: API Secret: {'set' if settings.BITFINEX_API_SECRET else 'not set'}"
 
             f"🔍 DEBUG: API Secret is {'set' if settings.BITFINEX_API_SECRET else 'not set'}"
-        main
+        
         )
         logger.info(f"🔍 DEBUG: Headers: {redact_headers(headers)}")
         logger.info(f"🔍 DEBUG: Payload: {bitfinex_order}")


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/3](https://github.com/JohnCCarter/Genesis/security/code-scanning/3)

To fix the problem, we should avoid logging any part of the API secret. Instead, we can log whether the secret is set (e.g., log "set" or "not set") or simply omit logging the secret entirely. This preserves the ability to debug configuration issues without exposing sensitive information. The change should be made in `tradingbot-backend/rest/auth.py`, specifically at line 134, replacing the log statement that outputs the first 10 characters of the secret. No new imports or methods are required; just update the log statement to avoid exposing the secret.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sammanfattning av Sourcery

Bugfixar:
- Ersätter loggning av de första 10 tecknen av API-hemligheten med en närvarokontroll som loggar 'satt' eller 'inte satt'.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace logging of the first 10 characters of the API secret with a presence check that logs 'set' or 'not set'.

</details>