### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/tradingbot-backend/rest/auth.py
+++ b/tradingbot-backend/rest/auth.py
@@ -128,10 +128,10 @@ async def place_order(order: dict) -> dict:
         
         # Logga alla detaljer för debugging
         logger.info(
-            f"🔍 DEBUG: API Key (första 10 chars): {settings.BITFINEX_API_KEY[:10] if settings.BITFINEX_API_KEY else 'None'}..."
+            f"🔍 DEBUG: API Key is {'set' if settings.BITFINEX_API_KEY else 'not set'}"
         )
         logger.info(
-            f"🔍 DEBUG: API Secret (första 10 chars): {settings.BITFINEX_API_SECRET[:10] if settings.BITFINEX_API_SECRET else 'None'}..."
+            f"🔍 DEBUG: API Secret is {'set' if settings.BITFINEX_API_SECRET else 'not set'}"
         )
         logger.info(f"🔍 DEBUG: Headers: {redact_headers(headers)}")
         logger.info(f"🔍 DEBUG: Payload: {bitfinex_order}")


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/2](https://github.com/JohnCCarter/Genesis/security/code-scanning/2)

To fix the problem, we should avoid logging any part of the API key or secret, even partially. Instead, we can log whether the key/secret is set (e.g., "present" or "not set") without revealing any of its content. This preserves the ability to debug configuration issues without exposing sensitive data. The change should be made in `tradingbot-backend/rest/auth.py`, specifically replacing lines 131–134 to log only the presence/absence of the credentials, not their values or substrings. No new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Här är översättningen till svenska:

## Sammanfattning av Sourcery

Bugfixar:
- Ersätt partiella API-nyckel- och hemliga loggar med närvarokontroller för att förhindra exponering i klartext

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace partial API key and secret logs with presence checks to prevent clear-text exposure

</details>