### PR TITLE
Potential fix for code scanning alert no. 16: DOM text reinterpreted as HTML

### DIFF
--- a/tradingbot-backend/ws_test.html
+++ b/tradingbot-backend/ws_test.html
@@ -598,6 +598,14 @@
       let socket = null;
       let token = null;
 
+      function escapeHtml(str) {
+        return String(str)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
       function pretty(obj) {
         try {
           return JSON.stringify(obj, null, 2);
@@ -619,22 +627,22 @@
         const ts = new Date().toLocaleTimeString();
         if (typeof message === "object") {
           logHtml(
-            `<span class="timestamp">[${ts}]</span><span class="badge ${type}">${type.toUpperCase()}</span><pre>${pretty(
-              message
-            )}</pre>`
+            `<span class="timestamp">[${escapeHtml(ts)}]</span><span class="badge ${escapeHtml(type)}">${escapeHtml(type.toUpperCase())}</span><pre>${escapeHtml(pretty(message))}</pre>`
           );
         } else {
           logHtml(
-            `<span class="timestamp">[${ts}]</span><span class="badge ${type}">${type.toUpperCase()}</span><span>${message}</span>`
+            `<span class="timestamp">[${escapeHtml(ts)}]</span><span class="badge ${escapeHtml(type)}">${escapeHtml(type.toUpperCase())}</span><span>${escapeHtml(message)}</span>`
           );
         }
       }
       function logSection(title, data, type = "info") {
         const ts = new Date().toLocaleTimeString();
         const content =
-          typeof data === "string" ? data : `<pre>${pretty(data)}</pre>`;
+          typeof data === "string"
+            ? `<span>${escapeHtml(data)}</span>`
+            : `<pre>${escapeHtml(pretty(data))}</pre>`;
         logHtml(
-          `<span class="timestamp">[${ts}]</span><span class="badge ${type}">${type.toUpperCase()}</span><span class="title">${title}</span>${content}`
+          `<span class="timestamp">[${escapeHtml(ts)}]</span><span class="badge ${escapeHtml(type)}">${escapeHtml(type.toUpperCase())}</span><span class="title">${escapeHtml(title)}</span>${content}`
         );
       }
       async function updateRiskBanner() {


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/16](https://github.com/JohnCCarter/Genesis/security/code-scanning/16)

To fix this problem, we must ensure that any user-controlled data is properly escaped before being inserted into the DOM as HTML. The best way to do this is to avoid using `insertAdjacentHTML` for user data, and instead use `textContent` or `innerText` to insert plain text, or to escape any special HTML characters before insertion. In this case, the `logHtml` function should only use `insertAdjacentHTML` for markup that is generated by the application and not for user data. For user data, we should escape it or use `textContent`. Specifically, in the `log` and `logSection` functions, we should escape the `message` and `data` variables before including them in the HTML string, or build the DOM nodes using `createElement` and `textContent` for user data.

The best fix is to add an HTML-escaping function (e.g., `escapeHtml`) and use it on all user-controlled data before including it in HTML strings that are passed to `logHtml`. This function should replace `<`, `>`, `&`, `"`, and `'` with their corresponding HTML entities. The changes should be made in the region of the code where the HTML is constructed (lines 621, 628, 635, 637), and the escaping function should be defined in the same script block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
