### PR TITLE
security(codeql): redact error payloads; route syntax cleanups; helper scripts

### DIFF
--- a/scripts/fix_route_syntax.py
+++ b/scripts/fix_route_syntax.py
@@ -1,0 +1,52 @@
+"""
+# AI Change: Fix quoting and parentheses in REST error redactions
+(Agent: Codex, Date: 2025-09-18)
+
+Purpose: clean up accidental escaped quotes and extra parentheses produced by
+previous automated replacements in routes/active_orders.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+
+FILES = [
+    pathlib.Path("tradingbot-backend/rest/routes.py"),
+    pathlib.Path("tradingbot-backend/rest/active_orders.py"),
+]
+
+
+def fix_text(src: str) -> str:
+    out = src
+    # Unescape specific tokens that should be plain strings in code
+    out = out.replace('\\"internal_error\\"', '"internal_error"')
+    out = out.replace('\\"ws_not_authenticated\\"', '"ws_not_authenticated"')
+    # Fix notification payload dicts accidentally closed
+    out = out.replace('"error": "internal_error")},', '"error": "internal_error"},')
+    # Fix double closing parenthesis in OrderResponse returns
+    out = re.sub(r'(return\s+OrderResponse\([^\n]*\))\)', r'\1', out)
+    # Fix specific ws update failed variant
+    out = out.replace('error="internal_error" or "ws_update_failed")', 'error="ws_update_failed")')
+    return out
+
+
+def main() -> int:
+    changed = False
+    for path in FILES:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        fixed = fix_text(text)
+        if fixed != text:
+            path.write_text(fixed, encoding="utf-8")
+            print(f"fixed: {path}")
+            changed = True
+        else:
+            print(f"nochange: {path}")
+    return 0 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/redact_errors.py
+++ b/scripts/redact_errors.py
@@ -1,0 +1,53 @@
+"""
+# AI Change: Redact error exposures in REST responses (Agent: Codex, Date: 2025-09-18)
+
+Replaces patterns like "error": str(e) and error=str(e) with generic values
+to eliminate stack-trace/exception detail exposure flagged by CodeQL.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+
+TARGETS = [
+    pathlib.Path("tradingbot-backend/rest/routes.py"),
+    pathlib.Path("tradingbot-backend/rest/active_orders.py"),
+]
+
+
+def redact_text(src: str) -> str:
+    # JSON dict form: "error": str(...)
+    out = re.sub(r'("error"\s*:\s*)str\([^)]*\)', r'\1"internal_error"', src)
+    # Kwarg form: error=str(...)
+    out = re.sub(r'(error\s*=\s*)str\([^)]*\)', r'\1"internal_error"', out)
+    # Cleanup accidental escaped quotes introduced by earlier runs
+    out = out.replace('\\"internal_error\\"', '"internal_error"')
+    out = out.replace('\\"ws_not_authenticated\\"', '"ws_not_authenticated"')
+    # Fix accidental extra parenthesis patterns
+    out = re.sub(r'error=\"internal_error\"\s*or\s*\"ws_update_failed\"\)', 'error=\"ws_update_failed\")', out)
+    out = re.sub(r'error=\"internal_error\"\)\)', 'error=\"internal_error\")', out)
+    out = out.replace('"internal_error")},', '"internal_error"},')
+    out = re.sub(r'("error"\s*:\s*"internal_error")\)\}', r'\1}', out)
+    return out
+
+
+def main() -> int:
+    changed_any = False
+    for path in TARGETS:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        redacted = redact_text(text)
+        if redacted != text:
+            path.write_text(redacted, encoding="utf-8")
+            print(f"redacted: {path}")
+            changed_any = True
+        else:
+            print(f"nochange: {path}")
+    return 0 if changed_any else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tradingbot-backend/rest/active_orders.py
+++ b/tradingbot-backend/rest/active_orders.py
@@ -231,7 +231,7 @@ class ActiveOrdersService:
                     results.append({"id": order.id, "success": True})
                 except Exception as ex:
                     logger.error(f"Fel vid avbrytning av order {order.id}: {ex}")
-                    results.append({"id": order.id, "success": False, "error": str(ex)})
+                    results.append({"id": order.id, "success": False, "error": "internal_error"})
 
             num_success = len([r for r in results if r.get("success")])
             return {
@@ -282,7 +282,7 @@ class ActiveOrdersService:
 
                 except Exception as e:
                     logger.error(f"Fel vid avbrytning av order {order.id}: {e}")
-                    results.append({"id": order.id, "success": False, "error": str(e)})
+                    results.append({"id": order.id, "success": False, "error": "internal_error"})
 
             return {
                 "success": True,


### PR DESCRIPTION
- Redact JSON error payloads in REST (`routes.py`, `active_orders.py`) to avoid exception detail exposure
- Keep `prob_train.py` safe path checks; no change needed beyond prior hardening
- Add helper scripts `scripts/redact_errors.py` and `scripts/fix_route_syntax.py`
- Hooks green (black/ruff)

This should close remaining stack-trace exposure alerts referencing error fields.