### PR TITLE
Potential fix for code scanning alert no. 68: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/risk_guards.py
+++ b/tradingbot-backend/services/risk_guards.py
@@ -356,7 +356,7 @@ class RiskGuardsService:
             return status
         except Exception as e:
             logger.error(f"Kunde inte hämta guards status: {e}")
-            return {"error": str(e)}
+            return {"error": "internal_error"}
 
     def update_guard_config(self, guard_name: str, config: dict[str, Any]) -> bool:
         """Uppdatera konfiguration för en riskvakt."""


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/68](https://github.com/JohnCCarter/Genesis/security/code-scanning/68)

**General approach:**  
Update the `get_guards_status` method in `RiskGuardsService` so that it never exposes exception messages or stack traces to the API client. On error, it should log the details server-side, but always return a generic error dictionary to the caller.

**Detailed fix:**  
- Edit `services/risk_guards.py`:
  - In `get_guards_status`, replace the exception handler's return value from `{"error": str(e)}` to a generic `{"error": "internal_error"}` (or equivalent).
- No further change needed in `debug_routes.py` since the endpoint already logs and returns an internal error marker if an exception arises at the API level.

**Implementation:**  
- Only edit `services/risk_guards.py`, specifically the exception handler in `get_guards_status`.
- No new imports/definitions are needed; simply adjust the return value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
