### PR TITLE
Potential fix for code scanning alert no. 62: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/regime_ablation.py
+++ b/tradingbot-backend/services/regime_ablation.py
@@ -474,7 +474,7 @@ class RegimeAblationService:
             return status
         except Exception as e:
             logger.error(f"❌ Kunde inte hämta regime status: {e}")
-            return {"error": str(e)}
+            raise RuntimeError("Kunde inte hämta regime status") from e
 
 
 # Global instans


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/62](https://github.com/JohnCCarter/Genesis/security/code-scanning/62)

To fix this issue, you must avoid returning internal error details from `regime_ablation.get_regime_status` directly to external users (API clients) via the `/regime/status` endpoint. The best approach is for `get_regime_status` to raise exceptions rather than returning error dictionaries. This way, the error will propagate to the FastAPI `try .. except` handler, where it is logged and converted to a generic HTTP 500 error response.  

**Necessary changes**:
- In `services/regime_ablation.py`, change the `get_regime_status` method so that, in the `except` block, it logs the error and raises an exception (e.g., `RuntimeError` or a custom exception) rather than returning `{"error": str(e)}`.
- In `rest/routes.py`, no change to the `/regime/status` endpoint handler is necessary, since it already has a `try/except` block handling exceptions and returning a generic error via HTTPException.

**Implementation**:
- Replace the return statement `return {"error": str(e)}` in `get_regime_status` with something like `raise RuntimeError("Kunde inte hämta regime status") from e`.
- Ensure error messages logged on the server remain detailed for debugging, but never sent back to users.
- No extra dependencies or imports required; use standard Python exception raising.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Här är sammanfattningen av pull-förfrågan översatt till svenska:

## Sammanfattning av Sourcery

Förbättrar felhanteringen i `get_regime_status` genom att kasta ett undantag istället för att returnera interna feldetaljer, vilket gör att FastAPI-hanteraren kan konvertera fel till ett generiskt HTTP 500-svar

Bugfixar:
- Förhindrar att intern felinformation exponeras för API-klienter genom att ersätta returneringen av fel-dictionaryn med ett undantag

Förbättringar:
- Loggar detaljerad felinformation på servern samtidigt som endast ett generiskt felmeddelande exponeras för användare via FastAPI

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve error handling in get_regime_status by raising an exception instead of returning internal error details, allowing the FastAPI handler to convert errors to a generic HTTP 500 response

Bug Fixes:
- Prevent internal error information from being exposed to API clients by replacing the error dictionary return with an exception

Enhancements:
- Log detailed error information on the server while exposing only a generic error message to users via FastAPI

</details>