### PR TITLE
Potential fix for code scanning alert no. 32: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/regime_ablation.py
+++ b/tradingbot-backend/services/regime_ablation.py
@@ -373,7 +373,7 @@ class RegimeAblationService:
 
         except Exception as e:
             logger.error(f"❌ Fel vid ablation test: {e}")
-            return {"error": str(e)}
+            return {"error": "Internal error occurred"}
 
     def _simulate_regime_performance(self, regime_names: list[str]) -> dict[str, Any]:
         """


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/32](https://github.com/JohnCCarter/Genesis/security/code-scanning/32)

To fix the problem, ensure that internal exception details are never sent to external API consumers. Instead, return a generic error object in responses while logging the real error on the server. Specifically, edit the `run_ablation_test` method in `regime_ablation.py` so that if an exception occurs, it logs the detailed error but returns a generic error message such as `{"error": "Internal error occurred"}`. This ensures that the API response does not expose implementation details or exception contents in the `result` value. Only the server logs will contain the error details.

**Required changes:**
- In `tradingbot-backend/services/regime_ablation.py`, edit `run_ablation_test` so that on exception, do NOT use `str(e)` in the returned dict, but return a generic error instead.
- No changes required to imports or API route definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sammanfattning av Sourcery

Bugfixar:
- Sluta returnera undantagsmeddelanden till konsumenter i `run_ablation_test`, och ersätt dem med ett generiskt felmeddelande

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop returning exception messages to consumers in run_ablation_test, replacing them with a generic error message

</details>