### PR TITLE
Potential fix for code scanning alert no. 57: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/unified_risk_service.py
+++ b/tradingbot-backend/services/unified_risk_service.py
@@ -457,7 +457,7 @@ class UnifiedRiskService:
             logger.error(f"❌ Fel vid hämtning av risk-status: {e}")
             return {
                 "timestamp": datetime.now().isoformat(),
-                "error": str(e),
+                "error": "Internal server error",
                 "overall_status": "error",
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/57](https://github.com/JohnCCarter/Genesis/security/code-scanning/57)

**How to, in general terms, fix the problem:**
- Ensure that detailed error information—especially anything derived from exception messages or stack traces—is logged server-side only, and that outward-facing API responses do not reveal these details to end users.
- For API error responses, return only generic error messages or status flags.

**Detailed fix for this codebase:**
- In `UnifiedRiskService.get_risk_status()`, modify the exception handler so that on error it returns a generic error status instead of exposing the actual exception string. 
- The returned dictionary should contain only general fields, such as an error timestamp and a generic message (e.g., `"error": "Internal server error"`), with no information about the exception's type or content.
- The existing logger call is enough for server-side error tracking.
- No need to change code outside of this method, as the caller simply returns whatever this returns to the client.

**Required changes:**
- `tradingbot-backend/services/unified_risk_service.py`, inside `UnifiedRiskService.get_risk_status()` — update the except block at lines 456–462.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
