### PR TITLE
Potential fix for code scanning alert no. 63: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/health_watchdog.py
+++ b/tradingbot-backend/services/health_watchdog.py
@@ -627,7 +627,7 @@ class HealthWatchdogService:
             }
         except Exception as e:
             logger.error(f"❌ Kunde inte hämta overall health: {e}")
-            return {"error": str(e)}
+            return {"error": "Internal server error"}
 
 
 # Global instans


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/63](https://github.com/JohnCCarter/Genesis/security/code-scanning/63)

To remediate this, the `get_overall_health` method in `tradingbot-backend/services/health_watchdog.py` should **not** leak `str(e)` or any internal error information to the API client. Instead, it should return a generic, non-informative error message such as `"error": "Internal server error"`. Exceptions should still be logged for diagnostic purposes, but only the generic message should be sent outward.

**Recommended Steps:**
- In the `get_overall_health` function, edit the except block so the returned value is `{"error": "Internal server error"}` rather than `{"error": str(e)}`.
- Make sure logging captures the real error for internal troubleshooting.

Only the code in `tradingbot-backend/services/health_watchdog.py` (lines in/around the except in `get_overall_health`) should be changed; all calling code can remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Här är översättningen till svenska:

## Sammanfattning av Sourcery

Bugfixar:
- Ersätt `str(e)` i felmeddelandet från `get_overall_health` med ett generiskt "Internal server error"-meddelande för att förhindra att interna undantag läcker ut till klienter

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace str(e) in the get_overall_health error response with a generic "Internal server error" message to prevent leaking internal exceptions to clients

</details>