### PR TITLE
security(codeql): harden output_dir in routes.py (path containment)

### DIFF
--- a/tradingbot-backend/rest/routes.py
+++ b/tradingbot-backend/rest/routes.py
@@ -2511,11 +2511,20 @@ async def prob_retrain_run(req: ProbRetrainRunRequest, _: bool = Depends(require
                     detail="Invalid output_dir: must be a simple relative sub-directory.",
                 )
 
+            # Disallow any path separators to keep a single-segment directory name
+            if "/" in user_dir or "\\" in user_dir:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid output_dir: no path separators allowed.",
+                )
+
             # Construct and resolve final path
             out_dir = _os.path.realpath(_os.path.join(safe_root_real, user_dir))
 
             # Strong containment check: out_dir must be a strict subdirectory of safe_root_real
-            if not is_safe_subdir(safe_root_real, out_dir):
+            real_root = _os.path.realpath(_os.path.abspath(safe_root_real))
+            real_out = _os.path.realpath(_os.path.abspath(out_dir))
+            if not (real_out.startswith(real_root + _os.sep) or real_out == real_root):
                 raise HTTPException(
                     status_code=400,
                     detail="Invalid output_dir: must be within allowed directory.",


### PR DESCRIPTION
- Strict output_dir validation and containment
- Run CodeQL on main after merge

## Sammanfattning från Sourcery

Förstärk valideringen av `output_dir` i `routes.py` för att förhindra path traversal genom att inte tillåta sökvägsavgränsare och genom att tvinga fram `realpath`-inneslutning, samt konfigurera CodeQL att köras på `main`-grenen efter sammanslagningar.

Förbättringar:
- Tillåt inte sökvägsavgränsare i användardefinierad `output_dir` för att tvinga fram kataloger med ett enda segment
- Använd `realpath`- och `abspath`-kontroller för att säkerställa att `output_dir` är innesluten inom den tillåtna roten

CI:
- Kör CodeQL-analys på `main`-grenen efter sammanslagningar

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden output_dir validation in routes.py to prevent path traversal by disallowing path separators and enforcing realpath containment, and configure CodeQL to run on the main branch after merges

Enhancements:
- Disallow path separators in user-specified output_dir to enforce single-segment directories
- Use realpath and abspath checks to ensure output_dir is contained within the allowed root

CI:
- Run CodeQL analysis on the main branch after merges

</details>