### PR TITLE
Potential fix for code scanning alert no. 53: Information exposure through an exception

### DIFF
--- a/tradingbot-backend/services/enhanced_observability_service.py
+++ b/tradingbot-backend/services/enhanced_observability_service.py
@@ -470,7 +470,8 @@ class EnhancedObservabilityService:
                 alerts.append(f"Exchange error rate kritisk: {exchange.error_rate_percent:.1f}%")
 
         except Exception as e:
-            alerts.append(f"Fel vid kontroll av alerts: {e}")
+            logger.exception(f"Fel vid kontroll av alerts: {e}")
+            alerts.append("Fel vid kontroll av alerts")
 
         return alerts
 


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis/security/code-scanning/53](https://github.com/JohnCCarter/Genesis/security/code-scanning/53)

To fix the problem, we must ensure that exception details generated in the `_get_critical_alerts` method of `EnhancedObservabilityService` are not exposed as part of the alerts or metrics objects returned by the API. When an exception is caught (e.g., on line 472), instead of including the stringified exception object (`{e}`) in the alert sent to the client, we should replace it with a generic error message for the user, yet continue to log the full details server-side for diagnostics.

Specifically, edit `services/enhanced_observability_service.py`:
- In the except block of `_get_critical_alerts`, replace the assignment
  - From: `alerts.append(f"Fel vid kontroll av alerts: {e}")`
  - To: `logger.exception(f"Fel vid kontroll av alerts: {e}")` and `alerts.append("Fel vid kontroll av alerts")`
- This ensures full details are logged, but the client only receives a generic error string.

This requires no new imports or methods, just an updated except block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Här är översättningen av pull request-sammanfattningen till svenska:

## Sammanfattning av Sourcery

Bugfixar:
- Maskera undantagsdetaljer i kritiska varningar och logga fullständigt undantag på serversidan för att förhindra exponering av känslig information

<details>
<summary>Original summary in English</summary>

## Sammanfattning från Sourcery

Buggfixar:
- Ersätt tillägg av strängifierat undantag i aviseringar med logger.exception och ett generiskt aviseringsmeddelande

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace appending of stringified exception in alerts with logger.exception and a generic alert message

</details>

</details>